### PR TITLE
Match file name 'asset' exactly

### DIFF
--- a/src/BAG.UnityPackage.Console/Program.cs
+++ b/src/BAG.UnityPackage.Console/Program.cs
@@ -94,7 +94,7 @@ namespace BAG.UnityPackage.Cmd
                                 Dictionary<string, string> toExtract = null;
 
                                 var pathEntries = from entry in tempArchive.Entries.ToArray()
-                                                  where Path.GetFileName(entry.FilePath).Contains("pathname")
+                                                  where Path.GetFileName(entry.FilePath).Equals("pathname")
                                                     && !entry.IsDirectory
                                                   select entry;
 
@@ -103,7 +103,7 @@ namespace BAG.UnityPackage.Cmd
                                     pathEntry => getFirstLine(pathEntry));
 
                                 var assets = from entry in tempArchive.Entries.ToArray()
-                                             where Path.GetFileName(entry.FilePath).Contains("asset")
+                                             where Path.GetFileName(entry.FilePath).Equals("asset")
                                                 && !entry.IsDirectory
                                              select new
                                              {
@@ -145,6 +145,7 @@ namespace BAG.UnityPackage.Cmd
                                         errors++;
                                         Console.ForegroundColor = ConsoleColor.Red;
                                         Console.WriteLine(Environment.NewLine + "error occurred while extracting: " + ex.Message + Environment.NewLine);
+                                        Console.ResetColor();
                                     }
                                 }
                             }


### PR DESCRIPTION
I tried extracting the standard asset .unitypackage files that come with Unity 5.2.3 and I was getting duplicate files. This is because there's now an 'asset.metadata' file in the .tar too:

```
feda0c18015b3284cabbc0da85254f9a/
feda0c18015b3284cabbc0da85254f9a/asset
feda0c18015b3284cabbc0da85254f9a/asset.meta
feda0c18015b3284cabbc0da85254f9a/pathname
feda0c18015b3284cabbc0da85254f9a/preview.png
```

and the `.Contains("asset")` check was also matching that, making two entries in `var.assets` that try to extract to the same path name.

Also fixes extraction exceptions not reverting to white text for the next extraction.

At first glance it also ought be possible to avoid the temp .tar file - `volume` seems to have a method that returns a stream. But I haven't tried that yet.

Thanks!
